### PR TITLE
Make yearly calendar responsive for phone

### DIFF
--- a/src/app/Calendar/Yearly/index.styles.scss
+++ b/src/app/Calendar/Yearly/index.styles.scss
@@ -68,3 +68,9 @@
   width: 100%;
   color: #202029;
 }
+
+@media only screen and (max-width: 426px) {
+    .yearlyMonth {
+        width: calc(100% / 2);
+    }
+}


### PR DESCRIPTION
only show 2 months in a row, not 3

Before: 
![image](https://user-images.githubusercontent.com/79075813/127267391-2e591594-bdd5-45ea-87c1-0243a42b61c2.png)

After:
![image](https://user-images.githubusercontent.com/79075813/127267417-6a37ab6b-a143-451d-9137-f2174ca59074.png)

And with only one month per row:
![image](https://user-images.githubusercontent.com/79075813/127267472-a0e8f902-b1be-4bab-8990-15d3554005c6.png)
